### PR TITLE
Potential fix for code scanning alert no. 8: Use of externally-controlled format string

### DIFF
--- a/frontend/src/utils/api.js
+++ b/frontend/src/utils/api.js
@@ -290,7 +290,7 @@ export const getConfig = async (name) => {
     const response = await api.get(endpoint);
     return response;
   } catch (error) {
-    console.error(`Error fetching config for host ${name || 'current host'}:`, error);
+    console.error('Error fetching config for host %s:', name || 'current host', error);
     throw error;
   }
 };


### PR DESCRIPTION
Potential fix for [https://github.com/monobilisim/monokit/security/code-scanning/8](https://github.com/monobilisim/monokit/security/code-scanning/8)

To fix the problem, we need to ensure that the user-provided `name` parameter is safely included in the log message. This can be achieved by using a `%s` specifier in the format string and passing the `name` parameter as an additional argument to `console.error`. This approach ensures that the `name` parameter is treated as a string and prevents any unintended format specifiers from being processed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
