### PR TITLE
Potential fix for code scanning alert no. 10: Use of externally-controlled format string

### DIFF
--- a/frontend/src/utils/api.js
+++ b/frontend/src/utils/api.js
@@ -293,7 +293,7 @@ export const getAwxJobLogs = async (hostname, jobId, focusOnHost = true) => {
     });
     return response;
   } catch (error) {
-    console.error(`Error fetching AWX job logs for job ${jobId}:`, error);
+    console.error('Error fetching AWX job logs for job %s:', jobId, error);
     throw error;
   }
 };


### PR DESCRIPTION
Potential fix for [https://github.com/monobilisim/monokit/security/code-scanning/10](https://github.com/monobilisim/monokit/security/code-scanning/10)

To fix the problem, we should ensure that the `jobId` is safely included in the log message. This can be achieved by using a `%s` specifier in the format string and passing the `jobId` as a separate argument to the `console.error` function. This approach ensures that the `jobId` is treated as a string and prevents any unintended format specifiers from being processed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
