### PR TITLE
Potential fix for code scanning alert no. 16: Use of externally-controlled format string

### DIFF
--- a/frontend/src/utils/api.js
+++ b/frontend/src/utils/api.js
@@ -294,7 +294,7 @@ export const forceDeleteHost = async (hostname) => {
     const response = await api.delete(`/hosts/${hostname}/force`);
     return response;
   } catch (error) {
-    console.error(`Error force deleting host ${hostname}:`, error);
+    console.error('Error force deleting host %s:', hostname, error);
     throw error;
   }
 };


### PR DESCRIPTION
Potential fix for [https://github.com/monobilisim/monokit/security/code-scanning/16](https://github.com/monobilisim/monokit/security/code-scanning/16)

To fix the issue, we will sanitize the `hostname` parameter before using it in the `console.error` statement. Instead of directly interpolating the `hostname` into the template string, we will use a `%s` specifier and pass the `hostname` as an additional argument to the `console.error` function. This ensures that the `hostname` is treated as a string and prevents any unintended format specifiers or malicious content from being interpreted.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
