### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,9 +1,10 @@
 name: CI
 
+permissions:
+  contents: read
+
 on:
   push:
-
-jobs:
   ci:
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
Potential fix for [https://github.com/monobilisim/monokit/security/code-scanning/1](https://github.com/monobilisim/monokit/security/code-scanning/1)

To fix the issue, we will add a `permissions` block at the root level of the workflow. This block will specify `contents: read`, which is sufficient for most CI workflows that do not require write access to the repository. This change ensures that the workflow adheres to the principle of least privilege and mitigates the risk of unintended write operations.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
