### PR TITLE
Potential fix for code scanning alert no. 26: Incorrect conversion between integer types

### DIFF
--- a/common/main.go
+++ b/common/main.go
@@ -8,6 +8,7 @@ import (
 	"path/filepath"
 	"strings"
 	"unicode"
+	"math"
 
 	"github.com/sirupsen/logrus"
 )
@@ -85,6 +86,11 @@ func ConvertBytes(bytes uint64) string {
 	}
 
 	// For smaller units, use integer format
+	if floatBytes > float64(math.MaxInt) {
+		return fmt.Sprintf("%d %s", math.MaxInt, sizes[i])
+	} else if floatBytes < float64(math.MinInt) {
+		return fmt.Sprintf("%d %s", math.MinInt, sizes[i])
+	}
 	return fmt.Sprintf("%d %s", int(floatBytes), sizes[i])
 }
 


### PR DESCRIPTION
Potential fix for [https://github.com/monobilisim/monokit/security/code-scanning/26](https://github.com/monobilisim/monokit/security/code-scanning/26)

To fix the issue, we need to ensure proper bounds checking during the conversion of `floatBytes` to `int` in the `ConvertBytes` function. Specifically:
1. Add a check to ensure that `floatBytes` is within the range of the `int` type before performing the conversion.
2. Use the `math` package to determine the maximum and minimum values for the `int` type (`math.MaxInt` and `math.MinInt`).
3. If `floatBytes` exceeds the bounds of the `int` type, handle the case gracefully (e.g., by clamping the value to the maximum or minimum).

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
