### PR TITLE
Potential fix for code scanning alert no. 28: Incorrect conversion between integer types

### DIFF
--- a/common/main.go
+++ b/common/main.go
@@ -94,7 +94,14 @@ func ConvertBytes(bytes uint64) string {
 	} else if floatBytes < 0 {
 		return fmt.Sprintf("%d %s", int64(0), sizes[i])
 	}
-	return fmt.Sprintf("%d %s", int64(floatBytes), sizes[i])
+	// Clamp floatBytes to [0, math.MaxInt64] before converting to int64
+	clamped := floatBytes
+	if clamped > float64(math.MaxInt64) {
+		clamped = float64(math.MaxInt64)
+	} else if clamped < 0 {
+		clamped = 0
+	}
+	return fmt.Sprintf("%d %s", int64(clamped), sizes[i])
 }
 
 func RemoveLockfile() {


### PR DESCRIPTION
Potential fix for [https://github.com/monobilisim/monokit/security/code-scanning/28](https://github.com/monobilisim/monokit/security/code-scanning/28)

To fix the problem, we need to ensure that before converting `floatBytes` to `int64`, we check that its value is within the valid range for `int64` (i.e., between 0 and `math.MaxInt64`). If `floatBytes` is outside this range, we should clamp it to the nearest valid value. This should be done in the final return statement on line 97, not just in the earlier conditional branches. The best way is to add a bounds check for `floatBytes` before converting it to `int64`, ensuring that the conversion is always safe and the output is correct. No new imports are needed, as `math` is already imported.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
