### PR TITLE
Potential fix for code scanning alert no. 29: Incorrect conversion between integer types

### DIFF
--- a/common/main.go
+++ b/common/main.go
@@ -75,6 +75,10 @@ func ConvertBytes(bytes uint64) string {
 		return "0 B"
 	}
 
+	// Clamp bytes to math.MaxInt64 before converting to float64 to avoid incorrect conversion
+	if bytes > uint64(math.MaxInt64) {
+		bytes = uint64(math.MaxInt64)
+	}
 	// Convert to float64 to preserve decimal precision
 	floatBytes := float64(bytes)
 	var i int


### PR DESCRIPTION
Potential fix for [https://github.com/monobilisim/monokit/security/code-scanning/29](https://github.com/monobilisim/monokit/security/code-scanning/29)

To fix the problem, we should ensure that the value being converted from `uint64` to `float64` (and then to `int64`) never exceeds `math.MaxInt64`. This can be achieved by clamping the original `bytes` argument to `math.MaxInt64` before converting it to `float64`. This way, we avoid any loss of precision or incorrect results due to the limitations of floating-point representation for large integers, and the subsequent cast to `int64` will always be safe. The change should be made in the `ConvertBytes` function in `common/main.go`, specifically at the start of the function, before any conversion to `float64` occurs. No new imports are needed, as `math` is already imported.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
