### PR TITLE
Potential fix for code scanning alert no. 29: Incorrect conversion between integer types

### DIFF
--- a/common/main.go
+++ b/common/main.go
@@ -105,6 +105,12 @@ func ConvertBytes(bytes uint64) string {
 	} else if clamped < 0 {
 		clamped = 0
 	}
+	// Ensure clamped is within int64 bounds before conversion
+	if clamped < float64(math.MinInt64) {
+		clamped = float64(math.MinInt64)
+	} else if clamped > float64(math.MaxInt64) {
+		clamped = float64(math.MaxInt64)
+	}
 	return fmt.Sprintf("%d %s", int64(clamped), sizes[i])
 }
 


### PR DESCRIPTION
Potential fix for [https://github.com/monobilisim/monokit/security/code-scanning/29](https://github.com/monobilisim/monokit/security/code-scanning/29)

To fix the problem, we need to ensure that any conversion from a potentially large `uint64` (parsed from untrusted input) to a smaller integer type (`int64`) is always preceded by a bounds check or clamp, especially after any arithmetic operations (such as division). In the `ConvertBytes` function, after dividing `floatBytes` by 1024 in a loop, we should clamp `floatBytes` to the range `[0, math.MaxInt64]` before converting to `int64` for display. The current code already does this, but to be extra safe and clear, we should ensure that the clamp is applied immediately before the conversion, and that the logic is robust against floating-point rounding errors. No new imports are needed, as `math` is already imported.

The only file to edit is `common/main.go`, specifically the `ConvertBytes` function.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
